### PR TITLE
Make CXXRTL testbench ~25% faster

### DIFF
--- a/test/sim/tb_cxxrtl/Makefile
+++ b/test/sim/tb_cxxrtl/Makefile
@@ -23,6 +23,7 @@ SYNTH_CMD += chparam -set REDUCED_BYPASS $(REDUCED_BYPASS) $(TOP);
 SYNTH_CMD += chparam -set MULDIV_UNROLL $(MULDIV_UNROLL) $(TOP);
 SYNTH_CMD += chparam -set MUL_FAST $(MUL_FAST) $(TOP);
 SYNTH_CMD += prep -flatten -top $(TOP); async2sync;
+SYNTH_CMD += splitnets -driver;
 SYNTH_CMD += write_cxxrtl dut.cpp
 
 dut.cpp:


### PR DESCRIPTION
The splitnets command removes a few feedback arcs.