### PR TITLE
Fix broken submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "test/riscv-compliance/riscv-compliance"]
 	path = test/riscv-compliance/riscv-compliance
 	url = https://github.com/riscv/riscv-compliance.git
-[submodule "test/riscv-compliance/riscv-arch-test"]
-	path = test/riscv-compliance/riscv-arch-test
+[submodule "test/sim/riscv-compliance/riscv-arch-test"]
+	path = test/sim/riscv-compliance/riscv-arch-test
 	url = https://github.com/riscv/riscv-arch-test.git
 [submodule "scripts"]
 	path = scripts


### PR DESCRIPTION
When cloning the repo git fails to init submodules:
```
$ git submodule update --init --recursive                          
fatal: No url found for submodule path 'test/sim/riscv-compliance/riscv-arch-test' in .gitmodules
```

This patch fixes submodule path