### PR TITLE
Readme.md / doc: clarify "naturally aligned regions", no TOR support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Hazard3 is a 3-stage RISC-V processor, implementing the `RV32I` instruction set 
 * `Zcmp`: push/pop instructions
 * Debug, Machine and User privilege/execution modes
 * Privileged instructions `ecall`, `ebreak`, `mret` and `wfi`
-* Physical memory protection (PMP) with up to 16 naturally aligned regions
+* Physical memory protection (PMP) with up to 16 naturally aligned regions (NA4 / NAPOT address matching, TOR not supported)
 
 You can [read the documentation here](doc/hazard3.pdf). (PDF link)
 

--- a/doc/sections/csr.adoc
+++ b/doc/sections/csr.adoc
@@ -273,7 +273,7 @@ Each `pmpcfg` register divides into four identical 8-bit chunks, each correspond
 |Bits | Name | Description
 | 7   | `L` | Lock region, and additionally enforce its permissions on M-mode as well as U-mode.
 | 6:5 | -   | RES0
-| 4:3 | `A` | Address-matching mode. Values supported are 0 (OFF), 2 (NA4, naturally aligned 4-byte) and 3 (NAPOT, naturally aligned power-of-two). Attempting to write an unsupported value will set the region to OFF.
+| 4:3 | `A` | Address-matching mode. Values supported are 0 (OFF), 2 (NA4, naturally aligned 4-byte) and 3 (NAPOT, naturally aligned power-of-two). 1 (TOR, top of range) is not supported. Attempting to write an unsupported value will set the region to OFF.
 | 2    | `X` | Execute permission
 | 1    | `W` | Write permission
 | 0    | `R` | Read permission


### PR DESCRIPTION
While NA4 and NAPOT are the only "naturally aligned" addressing modes in the RISC-V PMP (Privileged) spec, calling their support out by name, and clearly stating that the TOR addressing mode is not supported, can clarify this fact for software / OS developers.

This is a common point of confusion and frustration when porting to new RISC-V chips and so increased visbility of this limitation in the documentation and README might help.