### PR TITLE
Make sure sh/bash are able to parse project_env.sh properly

### DIFF
--- a/project_env.sh
+++ b/project_env.sh
@@ -2,9 +2,9 @@
 # Makefiles should work fine with just project_dir_paths.mk but it can be
 # convenient to have everything available in your shell.
 
-export PROJ_ROOT = $(git rev-parse --show-toplevel)
-export HDL       = ${PROJ_ROOT}/hdl
-export SCRIPTS   = ${PROJ_ROOT}/scripts
+export PROJ_ROOT="$(git rev-parse --show-toplevel)"
+export HDL="${PROJ_ROOT}/hdl"
+export SCRIPTS="${PROJ_ROOT}/scripts"
 
-export PATH      = "${PATH}:${PROJ_ROOT}/scripts"
-export PATH      = "${PATH}:/opt/riscv/bin"
+export PATH="${PATH}:${PROJ_ROOT}/scripts"
+export PATH="${PATH}:/opt/riscv/bin"


### PR DESCRIPTION
sh/bash don't allow spaces around `=` and assigned values should be quoted to avoid issues with spaces in paths.